### PR TITLE
Simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: elixir
 sudo: false
 otp_release:
   - 17.4
-script:
-  - mix test


### PR DESCRIPTION
Simplify `.travis.yml`. Don't need the `mix test` section.
